### PR TITLE
fix: resolve video from images/video.json and .mp4 fallback in redbook knowledge loader

### DIFF
--- a/desktop/electron/core/knowledgeLoader.ts
+++ b/desktop/electron/core/knowledgeLoader.ts
@@ -10,6 +10,7 @@ export interface WanderItem {
   title: string;
   content: string;
   cover?: string;
+  video?: string;
   meta: any;
 }
 
@@ -50,12 +51,45 @@ export async function getAllKnowledgeItems(): Promise<WanderItem[]> {
                cover = toAppAssetUrl(absolutePath);
           }
 
+          // Resolve video: check images/video.json first, then fall back to any .mp4 in images
+          let video: string | undefined;
+          if (meta.images) {
+            // Priority: images/video.json (structured metadata)
+            const videoJsonPath = path.join(redbookDir, dir.name, 'images', 'video.json');
+            try {
+              const videoJsonContent = await fs.readFile(videoJsonPath, 'utf-8');
+              const videoJson = JSON.parse(videoJsonContent);
+              if (videoJson && videoJson.url) {
+                if (videoJson.url.startsWith('http')) {
+                  video = videoJson.url;
+                } else {
+                  const absolutePath = path.join(redbookDir, dir.name, videoJson.url);
+                  video = toAppAssetUrl(absolutePath);
+                }
+              }
+            } catch {
+              // video.json not found, fall through to .mp4 scan
+            }
+
+            // Fallback: scan images for .mp4
+            if (!video) {
+              for (const img of meta.images) {
+                if (typeof img === 'string' && img.endsWith('.mp4')) {
+                  const absolutePath = path.join(redbookDir, dir.name, img);
+                  video = toAppAssetUrl(absolutePath);
+                  break;
+                }
+              }
+            }
+          }
+
           items.push({
             id: dir.name,
-            type: 'note',
+            type: video ? 'video' : 'note',
             title: meta.title || 'Untitled Note',
             content: meta.content || '',
             cover,
+            video,
             meta,
           });
         } catch {


### PR DESCRIPTION
## 问题描述

使用「知识库-小红书图文」导入视频笔记时，视频被错误渲染为图片。

**当前行为**：视频文件（images/video.mp4）被当作图片渲染：
```html
<img src=".../video.mp4" alt="图片 2" class="w-full h-full object-cover">
```

**期望行为**：应渲染为可播放的视频播放器（Knowledge.tsx 已有此渲染逻辑）：
```html
<video src=".../video.mp4" class="w-full h-full object-contain" muted playsInline preload="metadata"></video>
```

## 根因

`desktop/electron/core/knowledgeLoader.ts` 在加载小红书笔记时：
- 读取 `meta.images` 渲染图片列表
- 未识别 `images/video.mp4` 或 `images/video.json`
- 导致 `WanderItem` 的 `video` 字段始终为 undefined
- 前端 `Knowledge.tsx` 因 `note.video` 不存在，走到了 `<img>` 分支

## 修复内容

1. `WanderItem` 接口新增 `video?: string` 字段
2. 小红书笔记加载时，按优先级查找视频：
   - 优先读取 `images/video.json` 的 `url` 字段
   - 回退扫描 `images` 数组中任意 `.mp4` 文件
3. 解析到视频时，`type` 从 `'note'` 修正为 `'video'`

## 数据格式兼容性

convert.py 生成的数据格式：
```json
"images": ["images/cover.jpg", "images/video.mp4"]
```
`images/video.json`（新增）：
```json
{"type": "video", "url": "..."}
```
两种格式均可被正确识别。