### PR TITLE
[codex] Preserve explicit model capabilities in settings

### DIFF
--- a/desktop/src/pages/Settings.tsx
+++ b/desktop/src/pages/Settings.tsx
@@ -51,6 +51,7 @@ import {
   normalizeImageModelFetchBaseURL,
   normalizeAiModelDescriptors,
   normalizeSourceModels,
+  isLikelyTranscriptionModel,
   parseAiSources,
   parseEnvText,
   parseMcpServers,
@@ -1107,6 +1108,13 @@ export function Settings({
   const addModelModalCapability = addModelModalSource
     ? (sourceModelCapabilityDrafts[addModelModalSource.id] || 'chat')
     : 'chat';
+
+  const resolveCandidateModelCapability = useCallback((model: AiModelDescriptor): ModelCapability => {
+    if (model.capabilities.includes('transcription') || isLikelyTranscriptionModel(model.id)) {
+      return 'transcription';
+    }
+    return model.capabilities.find((capability) => capability !== 'chat') || model.capabilities[0] || 'chat';
+  }, []);
 
   const groupedAiPresets = useMemo<AiPresetGroup[]>(() => {
     const codingPlan = AI_SOURCE_PRESETS.filter((preset) => preset.group === 'coding-plan');
@@ -5860,7 +5868,7 @@ export function Settings({
                               setSourceModelDrafts((prev) => ({ ...prev, [addModelModalSource.id]: item.id }));
                               setSourceModelCapabilityDrafts((prev) => ({
                                 ...prev,
-                                [addModelModalSource.id]: item.capabilities[0] || 'chat',
+                                [addModelModalSource.id]: resolveCandidateModelCapability(item),
                               }));
                             }}
                             className="px-2 py-1 text-[11px] rounded border border-border hover:bg-surface-secondary transition-colors flex items-center gap-1.5"

--- a/desktop/src/pages/settings/shared.tsx
+++ b/desktop/src/pages/settings/shared.tsx
@@ -1460,12 +1460,15 @@ export const toAiModelDescriptor = (
     ...(Array.isArray(model?.capabilities) ? model.capabilities : []),
     model?.capability,
   ];
-  const capabilities = explicitCapabilities.some((value) => String(value || '').trim())
+  const hasExplicitCapabilities = explicitCapabilities.some((value) => String(value || '').trim());
+  const capabilities = hasExplicitCapabilities
     ? normalizeModelCapabilities(explicitCapabilities)
     : inferModelCapabilities(id);
   return {
     id,
-    capabilities: forcedCapabilities.length > 0 ? forcedCapabilities : capabilities,
+    capabilities: hasExplicitCapabilities
+      ? capabilities
+      : (forcedCapabilities.length > 0 ? forcedCapabilities : capabilities),
     inputCapabilities: getModelInputCapabilities(id),
   };
 };


### PR DESCRIPTION
## Summary

- Preserve explicit model capabilities selected in Settings instead of letting inferred model profiles override them.
- Default likely ASR candidates, such as `qwen3-asr-*`, to the transcription capability when selected from fetched model candidates.

## Root Cause

When a user manually added an ASR model and selected “转录模型”, `toAiModelDescriptor` still preferred forced capabilities inferred from broad model profile rules. A generic `qwen3` profile could therefore rewrite `qwen3-asr-flash-*` back to `chat`, causing the transcription model dropdown to stay empty after saving.

## User Impact

Users configuring Alibaba Bailian / DashScope ASR models could not persist the model as a transcription model, even after choosing the transcription capability in the UI.

## Validation

- `npx tsc --noEmit`
- `git diff --check`
