### PR TITLE
[codex] 修复设置页模型能力保存

### DIFF
--- a/desktop/src/pages/Settings.tsx
+++ b/desktop/src/pages/Settings.tsx
@@ -51,6 +51,7 @@ import {
   normalizeImageModelFetchBaseURL,
   normalizeAiModelDescriptors,
   normalizeSourceModels,
+  isLikelyTranscriptionModel,
   parseAiSources,
   parseEnvText,
   parseMcpServers,
@@ -1107,6 +1108,13 @@ export function Settings({
   const addModelModalCapability = addModelModalSource
     ? (sourceModelCapabilityDrafts[addModelModalSource.id] || 'chat')
     : 'chat';
+
+  const resolveCandidateModelCapability = useCallback((model: AiModelDescriptor): ModelCapability => {
+    if (model.capabilities.includes('transcription') || isLikelyTranscriptionModel(model.id)) {
+      return 'transcription';
+    }
+    return model.capabilities.find((capability) => capability !== 'chat') || model.capabilities[0] || 'chat';
+  }, []);
 
   const groupedAiPresets = useMemo<AiPresetGroup[]>(() => {
     const codingPlan = AI_SOURCE_PRESETS.filter((preset) => preset.group === 'coding-plan');
@@ -5860,7 +5868,7 @@ export function Settings({
                               setSourceModelDrafts((prev) => ({ ...prev, [addModelModalSource.id]: item.id }));
                               setSourceModelCapabilityDrafts((prev) => ({
                                 ...prev,
-                                [addModelModalSource.id]: item.capabilities[0] || 'chat',
+                                [addModelModalSource.id]: resolveCandidateModelCapability(item),
                               }));
                             }}
                             className="px-2 py-1 text-[11px] rounded border border-border hover:bg-surface-secondary transition-colors flex items-center gap-1.5"

--- a/desktop/src/pages/settings/shared.tsx
+++ b/desktop/src/pages/settings/shared.tsx
@@ -1460,12 +1460,15 @@ export const toAiModelDescriptor = (
     ...(Array.isArray(model?.capabilities) ? model.capabilities : []),
     model?.capability,
   ];
-  const capabilities = explicitCapabilities.some((value) => String(value || '').trim())
+  const hasExplicitCapabilities = explicitCapabilities.some((value) => String(value || '').trim());
+  const capabilities = hasExplicitCapabilities
     ? normalizeModelCapabilities(explicitCapabilities)
     : inferModelCapabilities(id);
   return {
     id,
-    capabilities: forcedCapabilities.length > 0 ? forcedCapabilities : capabilities,
+    capabilities: hasExplicitCapabilities
+      ? capabilities
+      : (forcedCapabilities.length > 0 ? forcedCapabilities : capabilities),
     inputCapabilities: getModelInputCapabilities(id),
   };
 };


### PR DESCRIPTION
## 变更内容

- 保留用户在设置页手动选择的模型能力，避免被模型名自动推断规则覆盖。
- 从候选模型中选择疑似 ASR 模型时，默认使用“转录模型”能力。

## 问题原因

用户添加 `qwen3-asr-*` 这类转录模型并选择“转录模型”后，保存流程会再次经过模型能力归一化。由于通用 `qwen3` 模型画像会把模型识别为聊天模型，显式选择的 `transcription` 能力被覆盖成 `chat`，导致转录模型下拉保存后仍为空。

## 用户影响

配置阿里百炼 / DashScope 等 ASR 模型时，用户即使在 UI 中选择了“转录模型”，保存后模型仍可能显示为聊天模型，无法在转录模型设置中选中。

## 验证

- `npx tsc --noEmit`
- `git diff --check`
